### PR TITLE
Fix server start sequence

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3,19 +3,26 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 require('dotenv').config();
 
-const app = express(); // <--- DAS HAT GEFEHLT!
+const app = express();
 
 app.use(cors());
 app.use(express.json());
-
-// MongoDB-Verbindung
-mongoose.connect(process.env.MONGO_URI)
-  .then(() => console.log('MongoDB connected'))
-  .catch(err => console.error(err));
 
 // Routen
 const adRoutes = require('./routes/adRoutes');
 app.use('/api/ads', adRoutes);
 
-// Server starten
-app.listen(5000, () => console.log('Server läuft auf Port 5000'));
+const PORT = process.env.PORT || 5000;
+
+async function startServer() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log('MongoDB connected');
+    app.listen(PORT, () => console.log(`Server läuft auf Port ${PORT}`));
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- wait for MongoDB connection before listening
- make port configurable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684087c1a904832cabecf33cd6626b56